### PR TITLE
Make spoofax_lexer work with modern versions of pygments

### DIFF
--- a/spoofax-pygments/spoofax_lexer.py
+++ b/spoofax-pygments/spoofax_lexer.py
@@ -9,13 +9,6 @@ from pygments.formatters.latex import LatexFormatter
 from pygments.lexer import Lexer
 from pygments.style import Style, StyleMeta
 from pygments.token import Token
-# check if pygments still has a compatibility layer
-try:
-    from pygments.util import add_metaclass
-    has_deprecated_pygments = True
-except ImportError:
-    has_deprecated_pygments = False
-
 
 # Subclass of Style that we can mess with without interfering with the original implementation
 class EmptyStyle(Style):
@@ -93,13 +86,8 @@ class CustomFormatter(LatexFormatter):
 
         # This extra style class is created to trigger the __new__ method in StyleMeta, to initialize the styles
         # that have been set in the CustomLexer
-        if has_deprecated_pygments:
-            @add_metaclass(StyleMeta)
-            class ExtraStyle(EmptyStyle):
-                pass
-        else:
-            class ExtraStyle(EmptyStyle, metaclass=StyleMeta):
-                pass
+        class ExtraStyle(EmptyStyle, metaclass=StyleMeta):
+            pass
 
 
         outfile.write("{\n")

--- a/spoofax-pygments/spoofax_lexer.py
+++ b/spoofax-pygments/spoofax_lexer.py
@@ -9,7 +9,12 @@ from pygments.formatters.latex import LatexFormatter
 from pygments.lexer import Lexer
 from pygments.style import Style, StyleMeta
 from pygments.token import Token
-from pygments.util import add_metaclass
+# check if pygments still has a compatibility layer
+try:
+    from pygments.util import add_metaclass
+    has_deprecated_pygments = True
+except ImportError:
+    has_deprecated_pygments = False
 
 
 # Subclass of Style that we can mess with without interfering with the original implementation
@@ -88,9 +93,14 @@ class CustomFormatter(LatexFormatter):
 
         # This extra style class is created to trigger the __new__ method in StyleMeta, to initialize the styles
         # that have been set in the CustomLexer
-        @add_metaclass(StyleMeta)
-        class ExtraStyle(EmptyStyle):
-            pass
+        if has_deprecated_pygments:
+            @add_metaclass(StyleMeta)
+            class ExtraStyle(EmptyStyle):
+                pass
+        else:
+            class ExtraStyle(EmptyStyle):
+                pass
+
 
         outfile.write("{\n")
 

--- a/spoofax-pygments/spoofax_lexer.py
+++ b/spoofax-pygments/spoofax_lexer.py
@@ -89,7 +89,6 @@ class CustomFormatter(LatexFormatter):
         class ExtraStyle(EmptyStyle, metaclass=StyleMeta):
             pass
 
-
         outfile.write("{\n")
 
         # Make sure that the settings for writing custom style commands (see next block) has the right settings.

--- a/spoofax-pygments/spoofax_lexer.py
+++ b/spoofax-pygments/spoofax_lexer.py
@@ -98,7 +98,7 @@ class CustomFormatter(LatexFormatter):
             class ExtraStyle(EmptyStyle):
                 pass
         else:
-            class ExtraStyle(EmptyStyle):
+            class ExtraStyle(EmptyStyle, metaclass=StyleMeta):
                 pass
 
 


### PR DESCRIPTION
Python 2 compatibility has been removed, meaning the import of `add_metaclass` fails when trying to run the script with a modern python/pygments version: https://github.com/pygments/pygments/commit/35544e2fc6eed0ce4a27ec7285aac71ff0ddc473