### PR TITLE
Since Minted 2.6 the pygments macro is always \PYG

### DIFF
--- a/spoofax-pygments/spoofax_lexer.py
+++ b/spoofax-pygments/spoofax_lexer.py
@@ -92,9 +92,8 @@ class CustomFormatter(LatexFormatter):
         outfile.write("{\n")
 
         # Make sure that the settings for writing custom style commands (see next block) has the right settings.
-        # The command prefix is `PYGdefault` when no style has been set using `\usemintedstyle`.
+        # The command prefix is `PYG` when no style has been set using `\usemintedstyle`.
         cp = self.commandprefix
-        cp = (cp + "default") if cp == "PYG" else cp
         self.options["commandprefix"] = cp
         self.options["style"] = ExtraStyle
 


### PR DESCRIPTION
See: https://github.com/gpoore/minted/releases/tag/v2.6

I'm not sure if this code is correct when a custom style is used, but at least it works for the default style.
